### PR TITLE
refactor: consolidate config files and align CI with local checks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,12 +24,7 @@
       "Bash(pnpm tsc)",
       "Bash(pnpm textlint)"
     ],
-    "deny": [
-      "Read(.env*)",
-      "Read(**/.env*)",
-      "Read(*.pem)",
-      "Read(*.key)"
-    ]
+    "deny": ["Read(.env*)", "Read(**/.env*)", "Read(*.pem)", "Read(*.key)"]
   },
   "hooks": {
     "PreToolUse": [

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,25 +13,21 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
           fetch-depth: 0
           persist-credentials: false
-      
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10.17.1
-          run_install: false
-      
-      - name: Download deps
-        shell: bash
-        run: pnpm install 
 
-      - name: package build
-        shell: bash
+      - uses: aquaproj/aqua-installer@ea518c135a02fc11ff8024364510c181a5c6b342 # v4.0.3
+        with:
+          aqua_version: v2.53.6
+
+      - name: Download deps
+        run: pnpm i --frozen-lockfile
+
+      - name: Package build
         run: pnpm build
-      
+
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/setup-pnpm-workflow.yml
+++ b/.github/workflows/setup-pnpm-workflow.yml
@@ -18,6 +18,12 @@ jobs:
 
       - name: Package build
         run: pnpm build
-      
+
+      - name: Type check
+        run: pnpm tsc
+
       - name: Run biome check
         run: pnpm biome:check
+
+      - name: Run knip
+        run: pnpm knip

--- a/api/src/gen/openapi.ts
+++ b/api/src/gen/openapi.ts
@@ -5,21 +5,19 @@
  * API
  * OpenAPI spec version: 1.0.0
  */
-import axios from 'axios';
-import type {
-  AxiosRequestConfig,
-  AxiosResponse
-} from 'axios';
+
+import type { AxiosRequestConfig, AxiosResponse } from "axios";
+import axios from "axios";
 
 /**
  * A machine readable error code.
  */
-export type ErrBadRequestErrorCode = typeof ErrBadRequestErrorCode[keyof typeof ErrBadRequestErrorCode];
-
+export type ErrBadRequestErrorCode =
+  (typeof ErrBadRequestErrorCode)[keyof typeof ErrBadRequestErrorCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ErrBadRequestErrorCode = {
-  BAD_REQUEST: 'BAD_REQUEST',
+  BAD_REQUEST: "BAD_REQUEST",
 } as const;
 
 export type ErrBadRequestError = {
@@ -40,12 +38,12 @@ export interface ErrBadRequest {
 /**
  * A machine readable error code.
  */
-export type ErrUnauthorizedErrorCode = typeof ErrUnauthorizedErrorCode[keyof typeof ErrUnauthorizedErrorCode];
-
+export type ErrUnauthorizedErrorCode =
+  (typeof ErrUnauthorizedErrorCode)[keyof typeof ErrUnauthorizedErrorCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ErrUnauthorizedErrorCode = {
-  UNAUTHORIZED: 'UNAUTHORIZED',
+  UNAUTHORIZED: "UNAUTHORIZED",
 } as const;
 
 export type ErrUnauthorizedError = {
@@ -66,12 +64,12 @@ export interface ErrUnauthorized {
 /**
  * A machine readable error code.
  */
-export type ErrForbiddenErrorCode = typeof ErrForbiddenErrorCode[keyof typeof ErrForbiddenErrorCode];
-
+export type ErrForbiddenErrorCode =
+  (typeof ErrForbiddenErrorCode)[keyof typeof ErrForbiddenErrorCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ErrForbiddenErrorCode = {
-  FORBIDDEN: 'FORBIDDEN',
+  FORBIDDEN: "FORBIDDEN",
 } as const;
 
 export type ErrForbiddenError = {
@@ -92,12 +90,12 @@ export interface ErrForbidden {
 /**
  * A machine readable error code.
  */
-export type ErrNotFoundErrorCode = typeof ErrNotFoundErrorCode[keyof typeof ErrNotFoundErrorCode];
-
+export type ErrNotFoundErrorCode =
+  (typeof ErrNotFoundErrorCode)[keyof typeof ErrNotFoundErrorCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ErrNotFoundErrorCode = {
-  NOT_FOUND: 'NOT_FOUND',
+  NOT_FOUND: "NOT_FOUND",
 } as const;
 
 export type ErrNotFoundError = {
@@ -118,12 +116,12 @@ export interface ErrNotFound {
 /**
  * A machine readable error code.
  */
-export type ErrConflictErrorCode = typeof ErrConflictErrorCode[keyof typeof ErrConflictErrorCode];
-
+export type ErrConflictErrorCode =
+  (typeof ErrConflictErrorCode)[keyof typeof ErrConflictErrorCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ErrConflictErrorCode = {
-  CONFLICT: 'CONFLICT',
+  CONFLICT: "CONFLICT",
 } as const;
 
 export type ErrConflictError = {
@@ -144,12 +142,12 @@ export interface ErrConflict {
 /**
  * A machine readable error code.
  */
-export type ErrTooManyRequestsErrorCode = typeof ErrTooManyRequestsErrorCode[keyof typeof ErrTooManyRequestsErrorCode];
-
+export type ErrTooManyRequestsErrorCode =
+  (typeof ErrTooManyRequestsErrorCode)[keyof typeof ErrTooManyRequestsErrorCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ErrTooManyRequestsErrorCode = {
-  TOO_MANY_REQUESTS: 'TOO_MANY_REQUESTS',
+  TOO_MANY_REQUESTS: "TOO_MANY_REQUESTS",
 } as const;
 
 export type ErrTooManyRequestsError = {
@@ -170,12 +168,12 @@ export interface ErrTooManyRequests {
 /**
  * A machine readable error code.
  */
-export type ErrInternalServerErrorErrorCode = typeof ErrInternalServerErrorErrorCode[keyof typeof ErrInternalServerErrorErrorCode];
-
+export type ErrInternalServerErrorErrorCode =
+  (typeof ErrInternalServerErrorErrorCode)[keyof typeof ErrInternalServerErrorErrorCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ErrInternalServerErrorErrorCode = {
-  INTERNAL_SERVER_ERROR: 'INTERNAL_SERVER_ERROR',
+  INTERNAL_SERVER_ERROR: "INTERNAL_SERVER_ERROR",
 } as const;
 
 export type ErrInternalServerErrorError = {
@@ -194,99 +192,99 @@ export interface ErrInternalServerError {
 }
 
 export type ListStreamsParams = {
-limit: string;
-page: string;
-platform?: ListStreamsPlatform;
-status?: ListStreamsStatus;
-memberType?: ListStreamsMemberType;
-startDateFrom?: string;
-startDateTo?: string;
-endedAt?: string;
-languageCode?: string;
-orderBy?: ListStreamsOrderBy;
+  limit: string;
+  page: string;
+  platform?: ListStreamsPlatform;
+  status?: ListStreamsStatus;
+  memberType?: ListStreamsMemberType;
+  startDateFrom?: string;
+  startDateTo?: string;
+  endedAt?: string;
+  languageCode?: string;
+  orderBy?: ListStreamsOrderBy;
 };
 
-export type ListStreamsPlatform = typeof ListStreamsPlatform[keyof typeof ListStreamsPlatform];
-
+export type ListStreamsPlatform =
+  (typeof ListStreamsPlatform)[keyof typeof ListStreamsPlatform];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListStreamsPlatform = {
-  youtube: 'youtube',
-  twitch: 'twitch',
-  twitcasting: 'twitcasting',
-  niconico: 'niconico',
-  unknown: 'unknown',
+  youtube: "youtube",
+  twitch: "twitch",
+  twitcasting: "twitcasting",
+  niconico: "niconico",
+  unknown: "unknown",
 } as const;
 
-export type ListStreamsStatus = typeof ListStreamsStatus[keyof typeof ListStreamsStatus];
-
+export type ListStreamsStatus =
+  (typeof ListStreamsStatus)[keyof typeof ListStreamsStatus];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListStreamsStatus = {
-  live: 'live',
-  upcoming: 'upcoming',
-  ended: 'ended',
-  unknown: 'unknown',
+  live: "live",
+  upcoming: "upcoming",
+  ended: "ended",
+  unknown: "unknown",
 } as const;
 
-export type ListStreamsMemberType = typeof ListStreamsMemberType[keyof typeof ListStreamsMemberType];
-
+export type ListStreamsMemberType =
+  (typeof ListStreamsMemberType)[keyof typeof ListStreamsMemberType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListStreamsMemberType = {
-  vspo_jp: 'vspo_jp',
-  vspo_en: 'vspo_en',
-  vspo_ch: 'vspo_ch',
-  vspo_all: 'vspo_all',
-  general: 'general',
+  vspo_jp: "vspo_jp",
+  vspo_en: "vspo_en",
+  vspo_ch: "vspo_ch",
+  vspo_all: "vspo_all",
+  general: "general",
 } as const;
 
-export type ListStreamsOrderBy = typeof ListStreamsOrderBy[keyof typeof ListStreamsOrderBy];
-
+export type ListStreamsOrderBy =
+  (typeof ListStreamsOrderBy)[keyof typeof ListStreamsOrderBy];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListStreamsOrderBy = {
-  asc: 'asc',
-  desc: 'desc',
+  asc: "asc",
+  desc: "desc",
 } as const;
 
-export type ListStreams200StreamsItemLanguageCode = typeof ListStreams200StreamsItemLanguageCode[keyof typeof ListStreams200StreamsItemLanguageCode];
-
+export type ListStreams200StreamsItemLanguageCode =
+  (typeof ListStreams200StreamsItemLanguageCode)[keyof typeof ListStreams200StreamsItemLanguageCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListStreams200StreamsItemLanguageCode = {
-  en: 'en',
-  ja: 'ja',
-  fr: 'fr',
-  de: 'de',
-  es: 'es',
-  cn: 'cn',
-  tw: 'tw',
-  ko: 'ko',
-  default: 'default',
+  en: "en",
+  ja: "ja",
+  fr: "fr",
+  de: "de",
+  es: "es",
+  cn: "cn",
+  tw: "tw",
+  ko: "ko",
+  default: "default",
 } as const;
 
-export type ListStreams200StreamsItemPlatform = typeof ListStreams200StreamsItemPlatform[keyof typeof ListStreams200StreamsItemPlatform];
-
+export type ListStreams200StreamsItemPlatform =
+  (typeof ListStreams200StreamsItemPlatform)[keyof typeof ListStreams200StreamsItemPlatform];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListStreams200StreamsItemPlatform = {
-  youtube: 'youtube',
-  twitch: 'twitch',
-  twitcasting: 'twitcasting',
-  niconico: 'niconico',
-  unknown: 'unknown',
+  youtube: "youtube",
+  twitch: "twitch",
+  twitcasting: "twitcasting",
+  niconico: "niconico",
+  unknown: "unknown",
 } as const;
 
-export type ListStreams200StreamsItemStatus = typeof ListStreams200StreamsItemStatus[keyof typeof ListStreams200StreamsItemStatus];
-
+export type ListStreams200StreamsItemStatus =
+  (typeof ListStreams200StreamsItemStatus)[keyof typeof ListStreams200StreamsItemStatus];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListStreams200StreamsItemStatus = {
-  live: 'live',
-  upcoming: 'upcoming',
-  ended: 'ended',
-  unknown: 'unknown',
+  live: "live",
+  upcoming: "upcoming",
+  ended: "ended",
+  unknown: "unknown",
 } as const;
 
 /**
@@ -342,31 +340,31 @@ export type ListStreams200 = {
 };
 
 export type ListCreatorsParams = {
-limit: string;
-page: string;
-memberType?: ListCreatorsMemberType;
+  limit: string;
+  page: string;
+  memberType?: ListCreatorsMemberType;
 };
 
-export type ListCreatorsMemberType = typeof ListCreatorsMemberType[keyof typeof ListCreatorsMemberType];
-
+export type ListCreatorsMemberType =
+  (typeof ListCreatorsMemberType)[keyof typeof ListCreatorsMemberType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListCreatorsMemberType = {
-  vspo_jp: 'vspo_jp',
-  vspo_en: 'vspo_en',
-  vspo_ch: 'vspo_ch',
-  general: 'general',
+  vspo_jp: "vspo_jp",
+  vspo_en: "vspo_en",
+  vspo_ch: "vspo_ch",
+  general: "general",
 } as const;
 
-export type ListCreators200CreatorsItemMemberType = typeof ListCreators200CreatorsItemMemberType[keyof typeof ListCreators200CreatorsItemMemberType];
-
+export type ListCreators200CreatorsItemMemberType =
+  (typeof ListCreators200CreatorsItemMemberType)[keyof typeof ListCreators200CreatorsItemMemberType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListCreators200CreatorsItemMemberType = {
-  vspo_jp: 'vspo_jp',
-  vspo_en: 'vspo_en',
-  vspo_ch: 'vspo_ch',
-  general: 'general',
+  vspo_jp: "vspo_jp",
+  vspo_en: "vspo_en",
+  vspo_ch: "vspo_ch",
+  general: "general",
 } as const;
 
 /**
@@ -478,43 +476,43 @@ export type PostStreamBody = {
   streamIds: string[];
 };
 
-export type PostStream200VideosItemLanguageCode = typeof PostStream200VideosItemLanguageCode[keyof typeof PostStream200VideosItemLanguageCode];
-
+export type PostStream200VideosItemLanguageCode =
+  (typeof PostStream200VideosItemLanguageCode)[keyof typeof PostStream200VideosItemLanguageCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const PostStream200VideosItemLanguageCode = {
-  en: 'en',
-  ja: 'ja',
-  fr: 'fr',
-  de: 'de',
-  es: 'es',
-  cn: 'cn',
-  tw: 'tw',
-  ko: 'ko',
-  default: 'default',
+  en: "en",
+  ja: "ja",
+  fr: "fr",
+  de: "de",
+  es: "es",
+  cn: "cn",
+  tw: "tw",
+  ko: "ko",
+  default: "default",
 } as const;
 
-export type PostStream200VideosItemPlatform = typeof PostStream200VideosItemPlatform[keyof typeof PostStream200VideosItemPlatform];
-
+export type PostStream200VideosItemPlatform =
+  (typeof PostStream200VideosItemPlatform)[keyof typeof PostStream200VideosItemPlatform];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const PostStream200VideosItemPlatform = {
-  youtube: 'youtube',
-  twitch: 'twitch',
-  twitcasting: 'twitcasting',
-  niconico: 'niconico',
-  unknown: 'unknown',
+  youtube: "youtube",
+  twitch: "twitch",
+  twitcasting: "twitcasting",
+  niconico: "niconico",
+  unknown: "unknown",
 } as const;
 
-export type PostStream200VideosItemStatus = typeof PostStream200VideosItemStatus[keyof typeof PostStream200VideosItemStatus];
-
+export type PostStream200VideosItemStatus =
+  (typeof PostStream200VideosItemStatus)[keyof typeof PostStream200VideosItemStatus];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const PostStream200VideosItemStatus = {
-  live: 'live',
-  upcoming: 'upcoming',
-  ended: 'ended',
-  unknown: 'unknown',
+  live: "live",
+  upcoming: "upcoming",
+  ended: "ended",
+  unknown: "unknown",
 } as const;
 
 /**
@@ -554,91 +552,91 @@ export type PostStream200 = {
 };
 
 export type ListClipsParams = {
-limit: string;
-page: string;
-platform?: ListClipsPlatform;
-clipType?: ListClipsClipType;
-languageCode?: string;
-orderBy?: ListClipsOrderBy;
-orderKey?: ListClipsOrderKey;
-afterPublishedAtDate?: string;
-beforePublishedAtDate?: string;
+  limit: string;
+  page: string;
+  platform?: ListClipsPlatform;
+  clipType?: ListClipsClipType;
+  languageCode?: string;
+  orderBy?: ListClipsOrderBy;
+  orderKey?: ListClipsOrderKey;
+  afterPublishedAtDate?: string;
+  beforePublishedAtDate?: string;
 };
 
-export type ListClipsPlatform = typeof ListClipsPlatform[keyof typeof ListClipsPlatform];
-
+export type ListClipsPlatform =
+  (typeof ListClipsPlatform)[keyof typeof ListClipsPlatform];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListClipsPlatform = {
-  youtube: 'youtube',
-  twitch: 'twitch',
-  twitcasting: 'twitcasting',
-  niconico: 'niconico',
-  unknown: 'unknown',
+  youtube: "youtube",
+  twitch: "twitch",
+  twitcasting: "twitcasting",
+  niconico: "niconico",
+  unknown: "unknown",
 } as const;
 
-export type ListClipsClipType = typeof ListClipsClipType[keyof typeof ListClipsClipType];
-
+export type ListClipsClipType =
+  (typeof ListClipsClipType)[keyof typeof ListClipsClipType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListClipsClipType = {
-  clip: 'clip',
-  short: 'short',
+  clip: "clip",
+  short: "short",
 } as const;
 
-export type ListClipsOrderBy = typeof ListClipsOrderBy[keyof typeof ListClipsOrderBy];
-
+export type ListClipsOrderBy =
+  (typeof ListClipsOrderBy)[keyof typeof ListClipsOrderBy];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListClipsOrderBy = {
-  asc: 'asc',
-  desc: 'desc',
+  asc: "asc",
+  desc: "desc",
 } as const;
 
-export type ListClipsOrderKey = typeof ListClipsOrderKey[keyof typeof ListClipsOrderKey];
-
+export type ListClipsOrderKey =
+  (typeof ListClipsOrderKey)[keyof typeof ListClipsOrderKey];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListClipsOrderKey = {
-  publishedAt: 'publishedAt',
-  viewCount: 'viewCount',
+  publishedAt: "publishedAt",
+  viewCount: "viewCount",
 } as const;
 
-export type ListClips200ClipsItemLanguageCode = typeof ListClips200ClipsItemLanguageCode[keyof typeof ListClips200ClipsItemLanguageCode];
-
+export type ListClips200ClipsItemLanguageCode =
+  (typeof ListClips200ClipsItemLanguageCode)[keyof typeof ListClips200ClipsItemLanguageCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListClips200ClipsItemLanguageCode = {
-  en: 'en',
-  ja: 'ja',
-  fr: 'fr',
-  de: 'de',
-  es: 'es',
-  cn: 'cn',
-  tw: 'tw',
-  ko: 'ko',
-  default: 'default',
+  en: "en",
+  ja: "ja",
+  fr: "fr",
+  de: "de",
+  es: "es",
+  cn: "cn",
+  tw: "tw",
+  ko: "ko",
+  default: "default",
 } as const;
 
-export type ListClips200ClipsItemPlatform = typeof ListClips200ClipsItemPlatform[keyof typeof ListClips200ClipsItemPlatform];
-
+export type ListClips200ClipsItemPlatform =
+  (typeof ListClips200ClipsItemPlatform)[keyof typeof ListClips200ClipsItemPlatform];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListClips200ClipsItemPlatform = {
-  youtube: 'youtube',
-  twitch: 'twitch',
-  twitcasting: 'twitcasting',
-  niconico: 'niconico',
-  unknown: 'unknown',
+  youtube: "youtube",
+  twitch: "twitch",
+  twitcasting: "twitcasting",
+  niconico: "niconico",
+  unknown: "unknown",
 } as const;
 
-export type ListClips200ClipsItemType = typeof ListClips200ClipsItemType[keyof typeof ListClips200ClipsItemType];
-
+export type ListClips200ClipsItemType =
+  (typeof ListClips200ClipsItemType)[keyof typeof ListClips200ClipsItemType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListClips200ClipsItemType = {
-  short: 'short',
-  clip: 'clip',
+  short: "short",
+  clip: "clip",
 } as const;
 
 /**
@@ -690,41 +688,41 @@ export type ListClips200 = {
 };
 
 export type ListEventsParams = {
-limit: string;
-page: string;
-visibility?: ListEventsVisibility;
-orderBy?: ListEventsOrderBy;
-startedDateFrom?: string;
-startedDateTo?: string;
+  limit: string;
+  page: string;
+  visibility?: ListEventsVisibility;
+  orderBy?: ListEventsOrderBy;
+  startedDateFrom?: string;
+  startedDateTo?: string;
 };
 
-export type ListEventsVisibility = typeof ListEventsVisibility[keyof typeof ListEventsVisibility];
-
+export type ListEventsVisibility =
+  (typeof ListEventsVisibility)[keyof typeof ListEventsVisibility];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListEventsVisibility = {
-  public: 'public',
-  private: 'private',
-  internal: 'internal',
+  public: "public",
+  private: "private",
+  internal: "internal",
 } as const;
 
-export type ListEventsOrderBy = typeof ListEventsOrderBy[keyof typeof ListEventsOrderBy];
-
+export type ListEventsOrderBy =
+  (typeof ListEventsOrderBy)[keyof typeof ListEventsOrderBy];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListEventsOrderBy = {
-  asc: 'asc',
-  desc: 'desc',
+  asc: "asc",
+  desc: "desc",
 } as const;
 
-export type ListEvents200EventsItemVisibility = typeof ListEvents200EventsItemVisibility[keyof typeof ListEvents200EventsItemVisibility];
-
+export type ListEvents200EventsItemVisibility =
+  (typeof ListEvents200EventsItemVisibility)[keyof typeof ListEvents200EventsItemVisibility];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListEvents200EventsItemVisibility = {
-  public: 'public',
-  private: 'private',
-  internal: 'internal',
+  public: "public",
+  private: "private",
+  internal: "internal",
 } as const;
 
 export type ListEvents200EventsItem = {
@@ -761,14 +759,14 @@ export type ListEvents200 = {
 /**
  * Event visibility status
  */
-export type CreateEventBodyVisibility = typeof CreateEventBodyVisibility[keyof typeof CreateEventBodyVisibility];
-
+export type CreateEventBodyVisibility =
+  (typeof CreateEventBodyVisibility)[keyof typeof CreateEventBodyVisibility];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const CreateEventBodyVisibility = {
-  public: 'public',
-  private: 'private',
-  internal: 'internal',
+  public: "public",
+  private: "private",
+  internal: "internal",
 } as const;
 
 export type CreateEventBody = {
@@ -782,14 +780,14 @@ export type CreateEventBody = {
   visibility?: CreateEventBodyVisibility;
 };
 
-export type CreateEvent201Visibility = typeof CreateEvent201Visibility[keyof typeof CreateEvent201Visibility];
-
+export type CreateEvent201Visibility =
+  (typeof CreateEvent201Visibility)[keyof typeof CreateEvent201Visibility];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const CreateEvent201Visibility = {
-  public: 'public',
-  private: 'private',
-  internal: 'internal',
+  public: "public",
+  private: "private",
+  internal: "internal",
 } as const;
 
 export type CreateEvent201 = {
@@ -803,14 +801,14 @@ export type CreateEvent201 = {
   updatedAt?: string;
 };
 
-export type GetEvent200Visibility = typeof GetEvent200Visibility[keyof typeof GetEvent200Visibility];
-
+export type GetEvent200Visibility =
+  (typeof GetEvent200Visibility)[keyof typeof GetEvent200Visibility];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const GetEvent200Visibility = {
-  public: 'public',
-  private: 'private',
-  internal: 'internal',
+  public: "public",
+  private: "private",
+  internal: "internal",
 } as const;
 
 export type GetEvent200 = {
@@ -825,68 +823,68 @@ export type GetEvent200 = {
 };
 
 export type ListFreechatsParams = {
-limit: string;
-page: string;
-languageCode?: string;
-memberType?: ListFreechatsMemberType;
-orderBy?: ListFreechatsOrderBy;
-orderKey?: ListFreechatsOrderKey;
+  limit: string;
+  page: string;
+  languageCode?: string;
+  memberType?: ListFreechatsMemberType;
+  orderBy?: ListFreechatsOrderBy;
+  orderKey?: ListFreechatsOrderKey;
 };
 
-export type ListFreechatsMemberType = typeof ListFreechatsMemberType[keyof typeof ListFreechatsMemberType];
-
+export type ListFreechatsMemberType =
+  (typeof ListFreechatsMemberType)[keyof typeof ListFreechatsMemberType];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListFreechatsMemberType = {
-  vspo_all: 'vspo_all',
-  vspo_jp: 'vspo_jp',
-  vspo_en: 'vspo_en',
+  vspo_all: "vspo_all",
+  vspo_jp: "vspo_jp",
+  vspo_en: "vspo_en",
 } as const;
 
-export type ListFreechatsOrderBy = typeof ListFreechatsOrderBy[keyof typeof ListFreechatsOrderBy];
-
+export type ListFreechatsOrderBy =
+  (typeof ListFreechatsOrderBy)[keyof typeof ListFreechatsOrderBy];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListFreechatsOrderBy = {
-  asc: 'asc',
-  desc: 'desc',
+  asc: "asc",
+  desc: "desc",
 } as const;
 
-export type ListFreechatsOrderKey = typeof ListFreechatsOrderKey[keyof typeof ListFreechatsOrderKey];
-
+export type ListFreechatsOrderKey =
+  (typeof ListFreechatsOrderKey)[keyof typeof ListFreechatsOrderKey];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListFreechatsOrderKey = {
-  publishedAt: 'publishedAt',
-  creatorName: 'creatorName',
+  publishedAt: "publishedAt",
+  creatorName: "creatorName",
 } as const;
 
-export type ListFreechats200FreechatsItemLanguageCode = typeof ListFreechats200FreechatsItemLanguageCode[keyof typeof ListFreechats200FreechatsItemLanguageCode];
-
+export type ListFreechats200FreechatsItemLanguageCode =
+  (typeof ListFreechats200FreechatsItemLanguageCode)[keyof typeof ListFreechats200FreechatsItemLanguageCode];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListFreechats200FreechatsItemLanguageCode = {
-  en: 'en',
-  ja: 'ja',
-  fr: 'fr',
-  de: 'de',
-  es: 'es',
-  cn: 'cn',
-  tw: 'tw',
-  ko: 'ko',
-  default: 'default',
+  en: "en",
+  ja: "ja",
+  fr: "fr",
+  de: "de",
+  es: "es",
+  cn: "cn",
+  tw: "tw",
+  ko: "ko",
+  default: "default",
 } as const;
 
-export type ListFreechats200FreechatsItemPlatform = typeof ListFreechats200FreechatsItemPlatform[keyof typeof ListFreechats200FreechatsItemPlatform];
-
+export type ListFreechats200FreechatsItemPlatform =
+  (typeof ListFreechats200FreechatsItemPlatform)[keyof typeof ListFreechats200FreechatsItemPlatform];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const ListFreechats200FreechatsItemPlatform = {
-  youtube: 'youtube',
-  twitch: 'twitch',
-  twitcasting: 'twitcasting',
-  niconico: 'niconico',
-  unknown: 'unknown',
+  youtube: "youtube",
+  twitch: "twitch",
+  twitcasting: "twitcasting",
+  niconico: "niconico",
+  unknown: "unknown",
 } as const;
 
 /**
@@ -937,86 +935,81 @@ export type ListFreechats200 = {
 };
 
 export const listStreams = <TData = AxiosResponse<ListStreams200>>(
-    params: ListStreamsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/streams`,{
+  params: ListStreamsParams,
+  options?: AxiosRequestConfig,
+): Promise<TData> => {
+  return axios.get("/api/streams", {
     ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
+    params: { ...params, ...options?.params },
+  });
+};
 
 export const listCreators = <TData = AxiosResponse<ListCreators200>>(
-    params: ListCreatorsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/creators`,{
+  params: ListCreatorsParams,
+  options?: AxiosRequestConfig,
+): Promise<TData> => {
+  return axios.get("/api/creators", {
     ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
+    params: { ...params, ...options?.params },
+  });
+};
 
 export const postStream = <TData = AxiosResponse<PostStream200>>(
-    postStreamBody: PostStreamBody, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/streams/search`,
-      postStreamBody,options
-    );
-  }
+  postStreamBody: PostStreamBody,
+  options?: AxiosRequestConfig,
+): Promise<TData> => {
+  return axios.post("/api/streams/search", postStreamBody, options);
+};
 
 export const listClips = <TData = AxiosResponse<ListClips200>>(
-    params: ListClipsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/clips`,{
+  params: ListClipsParams,
+  options?: AxiosRequestConfig,
+): Promise<TData> => {
+  return axios.get("/api/clips", {
     ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
+    params: { ...params, ...options?.params },
+  });
+};
 
 export const listEvents = <TData = AxiosResponse<ListEvents200>>(
-    params: ListEventsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/events`,{
+  params: ListEventsParams,
+  options?: AxiosRequestConfig,
+): Promise<TData> => {
+  return axios.get("/api/events", {
     ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
+    params: { ...params, ...options?.params },
+  });
+};
 
 export const createEvent = <TData = AxiosResponse<CreateEvent201>>(
-    createEventBody: CreateEventBody, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.post(
-      `/api/events`,
-      createEventBody,options
-    );
-  }
+  createEventBody: CreateEventBody,
+  options?: AxiosRequestConfig,
+): Promise<TData> => {
+  return axios.post("/api/events", createEventBody, options);
+};
 
 export const getEvent = <TData = AxiosResponse<GetEvent200>>(
-    id: string, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/events/${id}`,options
-    );
-  }
+  id: string,
+  options?: AxiosRequestConfig,
+): Promise<TData> => {
+  return axios.get(`/api/events/${id}`, options);
+};
 
 export const listFreechats = <TData = AxiosResponse<ListFreechats200>>(
-    params: ListFreechatsParams, options?: AxiosRequestConfig
- ): Promise<TData> => {
-    return axios.get(
-      `/api/freechats`,{
+  params: ListFreechatsParams,
+  options?: AxiosRequestConfig,
+): Promise<TData> => {
+  return axios.get("/api/freechats", {
     ...options,
-        params: {...params, ...options?.params},}
-    );
-  }
+    params: { ...params, ...options?.params },
+  });
+};
 
-export type ListStreamsResult = AxiosResponse<ListStreams200>
-export type ListCreatorsResult = AxiosResponse<ListCreators200>
-export type PostStreamResult = AxiosResponse<PostStream200>
-export type ListClipsResult = AxiosResponse<ListClips200>
-export type ListEventsResult = AxiosResponse<ListEvents200>
-export type CreateEventResult = AxiosResponse<CreateEvent201>
-export type GetEventResult = AxiosResponse<GetEvent200>
-export type ListFreechatsResult = AxiosResponse<ListFreechats200>
+export type ListStreamsResult = AxiosResponse<ListStreams200>;
+export type ListCreatorsResult = AxiosResponse<ListCreators200>;
+export type PostStreamResult = AxiosResponse<PostStream200>;
+export type ListClipsResult = AxiosResponse<ListClips200>;
+export type ListEventsResult = AxiosResponse<ListEvents200>;
+export type CreateEventResult = AxiosResponse<CreateEvent201>;
+export type GetEventResult = AxiosResponse<GetEvent200>;
+export type ListFreechatsResult = AxiosResponse<ListFreechats200>;

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -1,17 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "CommonJS",
-    "outDir": "./dist",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "exactOptionalPropertyTypes": true,
-    "skipLibCheck": true
-  }
+  "extends": "../tsconfig.base.json"
 }

--- a/api/tsup.config.js
+++ b/api/tsup.config.js
@@ -1,12 +1,3 @@
-import { defineConfig } from "tsup";
+import { createConfig } from "../tsup.config.base.js";
 
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["cjs", "esm"],
-  treeshake: true,
-  splitting: false,
-  sourcemap: true,
-  clean: true,
-  bundle: true,
-  dts: true,
-});
+export default createConfig("src/index.ts");

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "vcs": {
     "enabled": false,
     "clientKind": "git",
@@ -57,6 +57,5 @@
     "formatter": {
       "quoteStyle": "double"
     }
-  },
-  "overrides": []
+  }
 }

--- a/dayjs/tsconfig.json
+++ b/dayjs/tsconfig.json
@@ -1,17 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "CommonJS",
-    "outDir": "./dist",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "exactOptionalPropertyTypes": true,
-    "skipLibCheck": true
-  }
+  "extends": "../tsconfig.base.json"
 }

--- a/dayjs/tsup.config.js
+++ b/dayjs/tsup.config.js
@@ -1,12 +1,3 @@
-import { defineConfig } from "tsup";
+import { createConfig } from "../tsup.config.base.js";
 
-export default defineConfig({
-  entry: ["index.ts"],
-  format: ["cjs", "esm"],
-  treeshake: true,
-  splitting: false,
-  sourcemap: true,
-  clean: true,
-  bundle: true,
-  dts: true,
-});
+export default createConfig();

--- a/docs/plan/zesty-imagining-pancake.md
+++ b/docs/plan/zesty-imagining-pancake.md
@@ -1,0 +1,221 @@
+# Config Consolidation Plan
+
+## Context
+
+Configuration files across the monorepo have accumulated duplication and inconsistencies:
+- 4 identical `tsconfig.json` files (no shared base)
+- 4 near-identical `tsup.config.js` files
+- CI workflows missing checks that run locally (tsc, knip)
+- `release.yml` uses different pnpm setup method than build workflow
+- `turbo.json` defines biome tasks that are never used per-workspace
+- `biome.json` mixes includes/excludes and has stale schema version
+
+Goal: eliminate duplication, make CI match local checks, keep configs simple.
+
+---
+
+## Phase 1: tsconfig.json consolidation
+
+4 identical files -> 1 base + 4 one-liners.
+
+**Create** `tsconfig.base.json` (root):
+```json
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "CommonJS",
+    "outDir": "./dist",
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true
+  }
+}
+```
+
+**Replace** `api/tsconfig.json`, `dayjs/tsconfig.json`, `errors/tsconfig.json`, `logging/tsconfig.json` with:
+```json
+{
+  "extends": "../tsconfig.base.json"
+}
+```
+
+`outDir: "./dist"` resolves relative to each workspace's directory. With `noEmit: true`, it only affects resolution anyway.
+
+## Phase 2: tsup.config.js consolidation
+
+4 near-identical files (only `api` uses `src/index.ts`, others use `index.ts`).
+
+**Create** `tsup.config.base.js` (root):
+```js
+import { defineConfig } from "tsup";
+
+export function createConfig(entry = "index.ts") {
+  return defineConfig({
+    entry: [entry],
+    format: ["cjs", "esm"],
+    treeshake: true,
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    bundle: true,
+    dts: true,
+  });
+}
+```
+
+**Replace** `dayjs/tsup.config.js`, `errors/tsup.config.js`, `logging/tsup.config.js`:
+```js
+import { createConfig } from "../tsup.config.base.js";
+export default createConfig();
+```
+
+**Replace** `api/tsup.config.js`:
+```js
+import { createConfig } from "../tsup.config.base.js";
+export default createConfig("src/index.ts");
+```
+
+## Phase 3: turbo.json + package.json scripts cleanup
+
+**turbo.json** - Remove unused biome task definitions (biome runs at root, not per-workspace):
+```json
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "cache": true
+    },
+    "//#knip": {}
+  }
+}
+```
+
+**package.json scripts** - Simplify biome globs (`./**/**` -> `.`):
+```json
+"biome:check": "biome check .",
+"biome:format": "biome format --write .",
+"biome:lint": "biome lint --apply .",
+"biome:unsafe-fix": "biome check --fix --unsafe"
+```
+
+## Phase 4: biome.json cleanup
+
+- Update `$schema` from `2.3.8` to `2.3.12`
+- Separate `includes` / `excludes` (currently mixed with `!` prefixes in includes)
+- Remove empty `"overrides": []`
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "files": {
+    "ignoreUnknown": false,
+    "includes": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.json", "**/*.jsonc"],
+    "excludes": [
+      "**/node_modules/**/*", "**/dist/**/*", "**/build/**/*", "**/tools/**/*",
+      "**/*.config.js", "**/.turbo/**/*", "**/.git/**/*", "**/.vscode/**/*",
+      "**/.pnpm-store/**/*", "**/*.css", "**/tsconfig.json", "**/coverage/**/*"
+    ]
+  }
+}
+```
+
+(linter/formatter/javascript/assist sections unchanged)
+
+## Phase 5: CI workflow alignment
+
+### setup-pnpm-workflow.yml - Add missing tsc and knip steps
+
+```yaml
+steps:
+  - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+  - uses: aquaproj/aqua-installer@ea518c135a02fc11ff8024364510c181a5c6b342 # v4.0.3
+    with:
+      aqua_version: v2.53.6
+  - name: Download deps
+    run: pnpm i --frozen-lockfile
+  - name: Package build
+    run: pnpm build
+  - name: Type check
+    run: pnpm tsc
+  - name: Run biome check
+    run: pnpm biome:check
+  - name: Run knip
+    run: pnpm knip
+```
+
+### release.yml - Switch to aqua (consistent with build workflow)
+
+```yaml
+steps:
+  - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+    with:
+      fetch-depth: 0
+      persist-credentials: false
+  - uses: aquaproj/aqua-installer@ea518c135a02fc11ff8024364510c181a5c6b342 # v4.0.3
+    with:
+      aqua_version: v2.53.6
+  - name: Download deps
+    run: pnpm i --frozen-lockfile
+  - name: Package build
+    run: pnpm build
+  - name: Semantic Release
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    run: pnpm semantic-release
+```
+
+Changes: pinned checkout hash, replaced `pnpm/action-setup` with aqua, added `--frozen-lockfile`.
+
+---
+
+## No changes needed
+
+| Config | Reason |
+|--------|--------|
+| `knip.json` | Already correct. `ignoreDependencies` entries are necessary. |
+| `lefthook.yml` | Already simple and correct. |
+| `.textlintrc.json` | Already simple. |
+| `renovate.json` | Already extends shared config. |
+| `.releaserc.json` | Already correct. |
+| `aqua.yaml` | Only managing pnpm is correct. Biome is an npm package, not a standalone CLI. |
+
+---
+
+## File change summary
+
+| Action | File |
+|--------|------|
+| CREATE | `tsconfig.base.json` |
+| CREATE | `tsup.config.base.js` |
+| MODIFY | `api/tsconfig.json` |
+| MODIFY | `dayjs/tsconfig.json` |
+| MODIFY | `errors/tsconfig.json` |
+| MODIFY | `logging/tsconfig.json` |
+| MODIFY | `api/tsup.config.js` |
+| MODIFY | `dayjs/tsup.config.js` |
+| MODIFY | `errors/tsup.config.js` |
+| MODIFY | `logging/tsup.config.js` |
+| MODIFY | `turbo.json` |
+| MODIFY | `package.json` |
+| MODIFY | `biome.json` |
+| MODIFY | `.github/workflows/setup-pnpm-workflow.yml` |
+| MODIFY | `.github/workflows/release.yml` |
+
+## Verification
+
+```bash
+pnpm build           # Build all packages
+pnpm tsc             # Type check
+pnpm biome:check     # Lint/format check
+pnpm knip            # Unused code detection
+./scripts/post-edit-check.sh  # Full quality gate
+```

--- a/errors/tsconfig.json
+++ b/errors/tsconfig.json
@@ -1,17 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "CommonJS",
-    "outDir": "./dist",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "exactOptionalPropertyTypes": true,
-    "skipLibCheck": true
-  }
+  "extends": "../tsconfig.base.json"
 }

--- a/errors/tsup.config.js
+++ b/errors/tsup.config.js
@@ -1,12 +1,3 @@
-import { defineConfig } from "tsup";
+import { createConfig } from "../tsup.config.base.js";
 
-export default defineConfig({
-  entry: ["index.ts"],
-  format: ["cjs", "esm"],
-  treeshake: true,
-  splitting: false,
-  sourcemap: true,
-  clean: true,
-  bundle: true,
-  dts: true,
-});
+export default createConfig();

--- a/knip.json
+++ b/knip.json
@@ -14,14 +14,7 @@
       "project": "**/*.ts"
     }
   },
-  "ignore": [
-    "**/dist/**",
-    "**/node_modules/**"
-  ],
   "ignoreBinaries": [],
-  "ignoreDependencies": [
-    "lefthook",
-    "textlint-rule-write-good"
-  ],
+  "ignoreDependencies": ["lefthook", "textlint-rule-write-good"],
   "ignoreExportsUsedInFile": true
 }

--- a/logging/tsconfig.json
+++ b/logging/tsconfig.json
@@ -1,17 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "CommonJS",
-    "outDir": "./dist",
-    "noEmit": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "strictNullChecks": true,
-    "strictFunctionTypes": true,
-    "strictBindCallApply": true,
-    "strictPropertyInitialization": true,
-    "exactOptionalPropertyTypes": true,
-    "skipLibCheck": true
-  }
+  "extends": "../tsconfig.base.json"
 }

--- a/logging/tsup.config.js
+++ b/logging/tsup.config.js
@@ -1,12 +1,3 @@
-import { defineConfig } from "tsup";
+import { createConfig } from "../tsup.config.base.js";
 
-export default defineConfig({
-  entry: ["index.ts"],
-  format: ["cjs", "esm"],
-  treeshake: true,
-  splitting: false,
-  sourcemap: true,
-  clean: true,
-  bundle: true,
-  dts: true,
-});
+export default createConfig();

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "description": "",
   "scripts": {
     "build": "turbo build",
-    "biome:check": "biome check ./**/**",
-    "biome:format": "biome format --write ./**/**",
-    "biome:lint": "biome lint --apply ./**/**",
+    "biome:check": "biome check .",
+    "biome:format": "biome format --write .",
+    "biome:lint": "biome lint --apply .",
     "biome:unsafe-fix": "biome check --fix --unsafe",
     "knip": "knip",
     "tsc": "pnpm -r exec tsc --noEmit",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "CommonJS",
+    "outDir": "./dist",
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "exactOptionalPropertyTypes": true,
+    "skipLibCheck": true
+  },
+  "exclude": ["dist", "node_modules"]
+}

--- a/tsup.config.base.js
+++ b/tsup.config.base.js
@@ -1,0 +1,13 @@
+/** @param {string} [entry] */
+export function createConfig(entry = "index.ts") {
+  return {
+    entry: [entry],
+    format: ["cjs", "esm"],
+    treeshake: true,
+    splitting: false,
+    sourcemap: true,
+    clean: true,
+    bundle: true,
+    dts: true,
+  };
+}

--- a/turbo.json
+++ b/turbo.json
@@ -6,9 +6,6 @@
       "outputs": ["dist/**"],
       "cache": true
     },
-    "biome:check": {},
-    "biome:format": {},
-    "biome:lint": {},
     "//#knip": {}
   }
 }


### PR DESCRIPTION
## Summary
- Extract shared `tsconfig.base.json` and `tsup.config.base.js` to eliminate 4x duplication across workspaces
- Remove unused biome task definitions from `turbo.json`, simplify biome script globs
- Update `biome.json` schema version to match installed CLI (2.4.4), remove empty `overrides`
- Add `tsc` and `knip` steps to CI build workflow to match local pre-commit hooks
- Unify `release.yml` to use aqua instead of `pnpm/action-setup`, pin action hashes, add `--frozen-lockfile`
- Clean up redundant `ignore` entries in `knip.json`

## Test plan
- [x] `pnpm build` - all 4 packages build successfully
- [x] `pnpm tsc` - type check passes
- [x] `pnpm biome:check` - no new errors (1 pre-existing warning in logging)
- [x] `pnpm knip` - clean, no hints
- [x] `./scripts/post-edit-check.sh` - full quality gate passes
