### PR TITLE
chore: biome:check を pnpm check に置き換え

### DIFF
--- a/.github/workflows/setup-pnpm-workflow.yml
+++ b/.github/workflows/setup-pnpm-workflow.yml
@@ -22,8 +22,8 @@ jobs:
       - name: Type check
         run: pnpm tsc
 
-      - name: Run biome check
-        run: pnpm biome:check
+      - name: Run lint and format check
+        run: pnpm check
 
       - name: Run knip
         run: pnpm knip


### PR DESCRIPTION
## Summary
- reusable workflow の `pnpm biome:check` を `pnpm check` に変更
- 呼び出し元リポジトリ (vspo-server) が Biome → oxlint/oxfmt に移行したことに対応

## 関連PR
- vspo-lab/vspo-server#58